### PR TITLE
point out the mentee-support page

### DIFF
--- a/src/pages/menteesupport/page.jsx
+++ b/src/pages/menteesupport/page.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 const MenteeSupport = () => {
   return (
     <div>MenteeSupport page</div>
+    // this is the page you're looking for.
   )
 }
 


### PR DESCRIPTION
The mentee support page can be found in pages/menteesupport/page,js.

The content is:
```
import React from 'react'

const MenteeSupport = () => {
  return (
    <div>MenteeSupport page</div>
    // this is the page you're looking for.
  )
}

export default MenteeSupport
```